### PR TITLE
更新 Windows 安装程序版本信息处理

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,17 @@ jobs:
           APP_VERSION: ${{ steps.version.outputs.version }}
         run: |
           $version = $env:APP_VERSION
+          # 计算四段数字版本号 (X.X.X.X)，供 VersionInfoVersion 使用
+          # 去掉预发布标识 (如 1.0.0-beta -> 1.0.0)，按点分割并补齐到四段
+          $numericPart = ($version -split '[-+]')[0]
+          $parts = $numericPart -split '\.'
+          while ($parts.Count -lt 4) { $parts += '0' }
+          if ($parts.Count -gt 4) { $parts = $parts[0..3] }
+          $versionInfo = ($parts | ForEach-Object { if ([int]::TryParse($_, [ref]$null)) { [int]::Parse($_) } else { 0 } }) -join '.'
           $issFile = "scripts\windows\MarketAssistant.iss"
           $content = Get-Content $issFile -Raw
           $content = $content -replace '#define MyAppVersion ".*?"', "#define MyAppVersion `"$version`""
+          $content = $content -replace '#define MyAppVersionInfo ".*?"', "#define MyAppVersionInfo `"$versionInfo`""
           Set-Content $issFile -Value $content -NoNewline
           & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" $issFile
 

--- a/scripts/windows/MarketAssistant.iss
+++ b/scripts/windows/MarketAssistant.iss
@@ -4,6 +4,9 @@
 
 #define MyAppName "Market Assistant"
 #define MyAppVersion "1.0.0"
+; VersionInfoVersion / VersionInfoProductVersion 要求严格四段数字格式 X.X.X.X
+; MyAppVersion 可能为三段(1.0.0)或含预发布标识(1.0.0-beta)，此处单独定义四段版本
+#define MyAppVersionInfo "1.0.0.0"
 #define MyAppPublisher "MarketAssistant Team"
 #define MyAppURL "https://github.com/X2Agent/MarketAssistant"
 #define MyAppExeName "MarketAssistant.exe"
@@ -34,12 +37,12 @@ ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
 
 ; 版本信息
-VersionInfoVersion={#MyAppVersion}
+VersionInfoVersion={#MyAppVersionInfo}
 VersionInfoCompany={#MyAppPublisher}
 VersionInfoDescription={#MyAppName} Installer
 VersionInfoCopyright=Copyright (C) 2026 {#MyAppPublisher}
 VersionInfoProductName={#MyAppName}
-VersionInfoProductVersion={#MyAppVersion}
+VersionInfoProductVersion={#MyAppVersionInfo}
 
 ; UI 配置
 UninstallDisplayIcon={app}\{#MyAppExeName}

--- a/scripts/windows/build-installer.ps1
+++ b/scripts/windows/build-installer.ps1
@@ -56,10 +56,18 @@ Write-Host ""
 $issFile = "scripts\windows\MarketAssistant.iss"
 if ($Version) {
     Write-Host "📝 Updating version to $Version..." -ForegroundColor Yellow
+    # 计算四段数字版本号 (X.X.X.X)，供 VersionInfoVersion 使用
+    # 去掉预发布标识 (如 1.0.0-beta -> 1.0.0)，按点分割并补齐到四段
+    $numericPart = ($Version -split '[-+]')[0]
+    $parts = $numericPart -split '\.'
+    while ($parts.Count -lt 4) { $parts += '0' }
+    if ($parts.Count -gt 4) { $parts = $parts[0..3] }
+    $versionInfo = ($parts | ForEach-Object { if ([int]::TryParse($_, [ref]$null)) { [int]::Parse($_) } else { 0 } }) -join '.'
     $issContent = Get-Content $issFile -Raw
     $issContent = $issContent -replace '#define MyAppVersion ".*?"', "#define MyAppVersion `"$Version`""
+    $issContent = $issContent -replace '#define MyAppVersionInfo ".*?"', "#define MyAppVersionInfo `"$versionInfo`""
     Set-Content $issFile -Value $issContent -NoNewline
-    Write-Host "✓ Version updated" -ForegroundColor Green
+    Write-Host "✓ Version updated (display: $Version, version info: $versionInfo)" -ForegroundColor Green
     Write-Host ""
 }
 


### PR DESCRIPTION
- 在 release.yml 工作流中添加四段数字版本号计算逻辑
- 修改 build-installer.ps1 脚本以生成符合要求的版本信息格式
- 在 MarketAssistant.iss 中新增 MyAppVersionInfo 定义
- 将 VersionInfoVersion 和 VersionInfoProductVersion 指向新的四段版本格式
- 移除预发布标识并确保版本号严格遵循 X.X.X.X 格式
- 添加版本信息验证和调试输出功能
