### PR TITLE
更新 Windows 构建输出路径配置

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,12 @@ jobs:
             -p:DebugSymbols=false `
             -p:Version=${{ steps.version.outputs.version }} `
             -p:InformationalVersion=${{ steps.version.outputs.version }} `
-            -o ./publish/windows
+            -o ./Release/Windows-x64
         shell: pwsh
 
       - name: Clean debug files
         run: |
-          Get-ChildItem -Path ./publish/windows -Include "*.pdb", "*.xml" -Recurse | Remove-Item -Force
+          Get-ChildItem -Path ./Release/Windows-x64 -Include "*.pdb", "*.xml" -Recurse | Remove-Item -Force
         shell: pwsh
 
       - name: Install Inno Setup
@@ -96,7 +96,7 @@ jobs:
 
       - name: Create ZIP archive
         run: |
-          Compress-Archive -Path ./publish/windows/* `
+          Compress-Archive -Path ./Release/Windows-x64/* `
             -DestinationPath ./${{ env.APP_NAME }}-Windows-x64.zip `
             -CompressionLevel Optimal
         shell: pwsh


### PR DESCRIPTION
将构建输出目录从 ./publish/windows 更改为 ./Release/Windows-x64

更新调试文件清理脚本以匹配新的输出路径

修正 ZIP 打包命令中的源文件路径为新目录结构